### PR TITLE
"feat: team based color switching"

### DIFF
--- a/lib/core/base_layout.dart
+++ b/lib/core/base_layout.dart
@@ -1,3 +1,4 @@
+import 'package:f1_hub/providers/team_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:f1_hub/core/styles/app_styles.dart';
 import 'package:f1_hub/providers/theme_provider.dart';
@@ -21,7 +22,8 @@ class BaseLayout extends StatelessWidget {
   Widget build(BuildContext context) {
     final themeNotifier = Provider.of<ThemeProvider>(context);
     final isDarkMode = themeNotifier.themeMode == ThemeMode.dark;
-
+    final team = context.watch<TeamProvider>().selectedTeam;
+    final flagColor = AppStyles.getFlagColor(team);
     return RefreshIndicator(
       onRefresh: onRefresh ?? () async {},
       child: ListView(
@@ -35,7 +37,12 @@ class BaseLayout extends StatelessWidget {
                 children: [
                   // sample txt
                   Expanded(
-                    child: Text(title, style: AppStyles.headline1(context)),
+                    child: Text(
+                      title,
+                      style: AppStyles.headline1(
+                        context,
+                      ).copyWith(color: flagColor),
+                    ),
                   ),
                   SizedBox(width: 10),
 

--- a/lib/core/bottom_nav_bar.dart
+++ b/lib/core/bottom_nav_bar.dart
@@ -1,12 +1,15 @@
+import 'package:f1_hub/providers/team_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:f1_hub/core/styles/app_styles.dart';
 import 'package:f1_hub/screens/news/news_screen.dart';
+import 'package:provider/provider.dart';
 import '../screens/schedule/schedule_screen.dart';
 import '../screens/settings/settings_screen.dart';
 import '../screens/standing/standing_screen.dart';
 
 class BottomNavBar extends StatefulWidget {
-  const BottomNavBar({super.key});
+  final String teamName;
+  const BottomNavBar({super.key, required this.teamName});
 
   @override
   State<BottomNavBar> createState() => _BottomNavBarState();
@@ -31,6 +34,8 @@ class _BottomNavBarState extends State<BottomNavBar> {
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    final team = context.watch<TeamProvider>().selectedTeam;
+    final flagColor = AppStyles.getFlagColor(team);
 
     return Scaffold(
       backgroundColor: isDark ? AppStyles.bgColorDark : AppStyles.bgColorLight,
@@ -43,16 +48,13 @@ class _BottomNavBarState extends State<BottomNavBar> {
         child: BottomNavigationBar(
           currentIndex: _selectedIndex,
           onTap: _onItemTapped,
-          selectedItemColor: Colors.indigoAccent,
+          selectedItemColor: flagColor,
           unselectedItemColor: isDark ? Colors.grey[500] : Colors.grey[600],
           backgroundColor:
               isDark ? AppStyles.bgColorDark : AppStyles.darkModeTextColor,
           type: BottomNavigationBarType.fixed,
-          selectedLabelStyle: const TextStyle(
-            fontFamily: 'F1',
-            fontWeight: FontWeight.w600,
-          ),
-          unselectedLabelStyle: const TextStyle(fontFamily: 'F1'),
+          selectedLabelStyle: AppStyles.bottomBarSelectedLabel,
+          unselectedLabelStyle: AppStyles.bottomBarUnselectedLabel,
           items: const [
             BottomNavigationBarItem(
               icon: Icon(Icons.article_outlined),

--- a/lib/core/styles/app_styles.dart
+++ b/lib/core/styles/app_styles.dart
@@ -21,6 +21,48 @@ class AppStyles {
   static const Color warning = Color(0xFFFFC107);
   static const Color error = Color(0xFFE44152);
 
+  // Bottom Navigation Bar Colors
+  static const Color unselectedItemColorDarkMode = Color(0xFF9E9E9E);
+  static const Color unselectedItemColorLightMode = Color(0xFF757575);
+  static const Color selectedItemColor = Colors.indigoAccent;
+  static const Color transparent = Colors.transparent;
+
+  static const TextStyle bottomBarSelectedLabel = TextStyle(
+    fontFamily: 'F1',
+    fontWeight: FontWeight.w600,
+  );
+
+  static const TextStyle bottomBarUnselectedLabel = TextStyle(fontFamily: 'F1');
+
+  // team based color switching
+
+  static Color getFlagColor(String team) {
+    switch (team.toLowerCase()) {
+      case 'mclaren':
+        return const Color(0xFFFF8700);
+      case 'mercedes':
+        return const Color(0xFF00D2BE);
+      case 'ferrari':
+        return const Color(0xFFE41E26);
+      case 'redbull':
+        return const Color.fromARGB(255, 57, 118, 231);
+      case 'williams':
+        return const Color.fromARGB(255, 95, 128, 189);
+      case 'rbf1':
+        return const Color(0xFF6692FF);
+      case 'astonmartin':
+        return const Color(0xFF2D826D);
+      case 'sauber':
+        return const Color(0xFF52E252);
+      case 'haas':
+        return const Color(0xFFD0D1D3);
+      case 'alpine':
+        return const Color(0xFF0090FF);
+      default:
+        return const Color(0xFFFF8700);
+    }
+  }
+
   // Text Styles
   static TextStyle headline1(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:f1_hub/providers/team_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:f1_hub/core/bottom_nav_bar.dart';
@@ -18,9 +19,13 @@ void main() async {
 
   final themeProvider = ThemeProvider();
   await themeProvider.loadTheme();
+
   runApp(
-    ChangeNotifierProvider<ThemeProvider>.value(
-      value: themeProvider,
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider<ThemeProvider>.value(value: themeProvider),
+        ChangeNotifierProvider(create: (_) => TeamProvider()),
+      ],
       child: const MyApp(),
     ),
   );
@@ -32,6 +37,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeProvider = Provider.of<ThemeProvider>(context);
+    final team = context.watch<TeamProvider>().selectedTeam;
 
     return MaterialApp(
       debugShowCheckedModeBanner: false,
@@ -76,7 +82,7 @@ class MyApp extends StatelessWidget {
 
       // Routes
       routes: {
-        "/": (context) => BottomNavBar(),
+        "/": (context) => BottomNavBar(teamName: team),
         "/news": (context) => NewsScreen(),
         "/schedule": (context) => ScheduleScreen(),
         "/standing": (context) => StandingScreen(),

--- a/lib/providers/team_provider.dart
+++ b/lib/providers/team_provider.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class TeamProvider extends ChangeNotifier {
+  String _selectedTeam = '';
+  String get selectedTeam => _selectedTeam;
+
+  TeamProvider() {
+    _loadTeam();
+  }
+
+  Future<void> _loadTeam() async {
+    final prefs = await SharedPreferences.getInstance();
+    _selectedTeam = prefs.getString('selected_team') ?? '';
+    notifyListeners();
+  }
+
+  Future<void> setTeam(String team) async {
+    _selectedTeam = team;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('selected_team', team);
+  }
+}

--- a/lib/screens/news/news_screen.dart
+++ b/lib/screens/news/news_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:f1_hub/providers/team_provider.dart';
 import 'package:f1_hub/services/notification_services.dart';
 import 'package:f1_hub/utils/next_race_widget.dart';
 import 'package:flutter/material.dart';
@@ -123,6 +124,7 @@ class _NewsScreenState extends State<NewsScreen> {
   @override
   Widget build(BuildContext context) {
     Provider.of<ThemeProvider>(context);
+    final team = context.watch<TeamProvider>().selectedTeam;
 
     return BaseLayout(
       showThemeSwitcher: true,
@@ -138,6 +140,7 @@ class _NewsScreenState extends State<NewsScreen> {
               NewRaceCountdownCard(
                 gpTitle: raceName!,
                 initialRemainingTime: remaining!,
+                teamName: team,
               )
             else
               Center(

--- a/lib/screens/news/widgets/new_race_countdown_card.dart
+++ b/lib/screens/news/widgets/new_race_countdown_card.dart
@@ -1,15 +1,19 @@
 import 'dart:async';
+import 'package:f1_hub/providers/team_provider.dart';
 import 'package:flutter/material.dart';
-import 'package:f1_hub/core/styles/app_styles.dart';  
+import 'package:f1_hub/core/styles/app_styles.dart';
+import 'package:provider/provider.dart';
 
 class NewRaceCountdownCard extends StatefulWidget {
   final String gpTitle;
   final Duration initialRemainingTime;
+  final String teamName;
 
   const NewRaceCountdownCard({
     super.key,
     required this.gpTitle,
     required this.initialRemainingTime,
+    required this.teamName,
   });
 
   @override
@@ -53,6 +57,8 @@ class _NewRaceCountdownCardState extends State<NewRaceCountdownCard> {
 
   @override
   Widget build(BuildContext context) {
+    final team = context.watch<TeamProvider>().selectedTeam;
+    final flagColor = AppStyles.getFlagColor(team);
     return Container(
       padding: const EdgeInsets.symmetric(vertical: 25, horizontal: 15),
       decoration: AppStyles.card(context),
@@ -65,7 +71,7 @@ class _NewRaceCountdownCardState extends State<NewRaceCountdownCard> {
               children: [
                 Row(
                   children: [
-                    Icon(Icons.flag, color: Colors.deepOrangeAccent),
+                    Icon(Icons.flag, color: flagColor),
                     SizedBox(width: 8),
                     Text("Next Race", style: AppStyles.caption(context)),
                   ],
@@ -77,7 +83,7 @@ class _NewRaceCountdownCardState extends State<NewRaceCountdownCard> {
                   child: Text(
                     "In ${formatDuration(remainingTime)}",
                     style: AppStyles.body(context).copyWith(
-                      color: AppStyles.orange,
+                      color: flagColor,
                       fontWeight: FontWeight.bold,
                       fontSize: 18,
                     ),

--- a/lib/screens/schedule/schedule_screen.dart
+++ b/lib/screens/schedule/schedule_screen.dart
@@ -143,6 +143,7 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
                     NewRaceCountdownCard(
                       gpTitle: raceName!,
                       initialRemainingTime: remaining!,
+                      teamName: "",
                     ),
                     const SizedBox(height: 20),
                     Text(

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:f1_hub/providers/team_provider.dart';
 import 'package:f1_hub/services/api_services.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -20,11 +21,34 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   bool notificationsEnabled = true;
   bool willNotificationsBeEverTurnedOnAnyTimeSoon = false;
+  String? selectedTeam;
+
+  final List<String> f1Teams = [
+    'McLaren',
+    'Mercedes',
+    'Ferrari',
+    'RedBull',
+    'Williams',
+    'RBF1',
+    'AstonMartin',
+    'Sauber',
+    'Haas',
+    'Alpine',
+  ];
 
   @override
   void initState() {
     super.initState();
     _loadNotificationPreference();
+    _loadSelectedTeam();
+  }
+
+  Future<void> _loadSelectedTeam() async {
+    final prefs = await SharedPreferences.getInstance();
+
+    setState(() {
+      selectedTeam = prefs.getString('selected_team') ?? '';
+    });
   }
 
   Future<void> _loadNotificationPreference() async {
@@ -56,6 +80,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Widget build(BuildContext context) {
     final themeNotifier = Provider.of<ThemeProvider>(context);
     final isDarkMode = themeNotifier.isDark;
+    final teamProvider = Provider.of<TeamProvider>(context);
+
+    final selectedTeam = context.watch<TeamProvider>().selectedTeam;
 
     return BaseLayout(
       showThemeSwitcher: false,
@@ -64,6 +91,37 @@ class _SettingsScreenState extends State<SettingsScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            sectionTitle("Theme Preferences"),
+            ListTile(
+              contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+              title: const Text(
+                "Select Team Theme",
+                style: TextStyle(fontSize: 14, fontFamily: "F1"),
+              ),
+              subtitle: DropdownButton<String>(
+                value: selectedTeam,
+                isExpanded: true,
+                icon: const Icon(Icons.arrow_drop_down),
+                underline: const SizedBox(),
+                items:
+                    f1Teams.map((team) {
+                      return DropdownMenuItem<String>(
+                        value: team,
+                        child: Text(
+                          team,
+                          style: const TextStyle(fontFamily: "F1"),
+                        ),
+                      );
+                    }).toList(),
+                onChanged: (value) {
+                  if (value != null) {
+                    teamProvider.setTeam(value);
+                    // _saveSelectedTeam(value);
+                  }
+                },
+              ),
+            ),
+
             sectionTitle("Notifications"),
 
             ListTile(

--- a/lib/screens/standing/standing_screen.dart
+++ b/lib/screens/standing/standing_screen.dart
@@ -1,4 +1,5 @@
 import 'package:f1_hub/core/styles/app_styles.dart';
+import 'package:f1_hub/providers/team_provider.dart';
 import 'package:f1_hub/screens/standing/widgets/constructor_standings_list.dart';
 import 'package:f1_hub/screens/standing/widgets/driver_standings_list.dart';
 import 'package:flutter/material.dart';
@@ -7,6 +8,7 @@ import 'package:f1_hub/services/api_services.dart';
 import 'package:f1_hub/screens/standing/widgets/constructor_standing.dart';
 import 'package:f1_hub/screens/standing/widgets/driver_standing.dart';
 import 'package:f1_hub/screens/standing/widgets/standing_tabs.dart';
+import 'package:provider/provider.dart';
 
 class StandingScreen extends StatefulWidget {
   const StandingScreen({super.key});
@@ -82,6 +84,7 @@ class _StandingScreenState extends State<StandingScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final team = context.watch<TeamProvider>().selectedTeam;
     return BaseLayout(
       onRefresh: _loadStandings,
       title: 'Standings',
@@ -99,6 +102,7 @@ class _StandingScreenState extends State<StandingScreen> {
                         _selectedTab = value;
                       });
                     },
+                    teamName: team,
                   ),
                   SingleChildScrollView(
                     child: Column(

--- a/lib/screens/standing/widgets/standing_tabs.dart
+++ b/lib/screens/standing/widgets/standing_tabs.dart
@@ -1,16 +1,20 @@
+import 'package:f1_hub/providers/team_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:f1_hub/core/styles/app_styles.dart';
+import 'package:provider/provider.dart';
 
 enum StandingType { drivers, constructors }
 
 class StandingTabs extends StatelessWidget {
   final StandingType activeTab;
   final ValueChanged<StandingType> onTabSelected;
+  final String teamName;
 
   const StandingTabs({
     super.key,
     required this.activeTab,
     required this.onTabSelected,
+    required this.teamName,
   });
 
   @override
@@ -18,9 +22,14 @@ class StandingTabs extends StatelessWidget {
     bool isDriversActive = activeTab == StandingType.drivers;
     bool isConstructorsActive = activeTab == StandingType.constructors;
 
+    final team = context.watch<TeamProvider>().selectedTeam;
+    final flagColor = AppStyles.getFlagColor(team);
+
+    print("team, $team");
+    print("color, $flagColor");
     TextStyle? activeTextStyle = AppStyles.body(
       context,
-    ).copyWith(color: AppStyles.orange, fontWeight: FontWeight.bold);
+    ).copyWith(color: flagColor, fontWeight: FontWeight.bold);
 
     TextStyle? inactiveTextStyle = AppStyles.body(
       context,


### PR DESCRIPTION
Summary

Added dynamic team-based color theming. Users can now select their favorite F1 team in Settings, and the app updates instantly to match the team’s color

Changes
Added TeamProvider for persistence monitoring via SharedPreferences

Updated SettingsScreen, main and others to follow